### PR TITLE
Fix socket initialization as it cause issue when user first time use the app

### DIFF
--- a/whatsapp-client/src/redux/sagas/authSagas.ts
+++ b/whatsapp-client/src/redux/sagas/authSagas.ts
@@ -43,7 +43,7 @@ function* googleSignIn(payload?: any) {
     process.env.REACT_APP_SERVER_URL as string,
     getAccessToken()
   );
-  yield call(initializedSocket.getActiveSocket);
+  yield call([initializedSocket, initializedSocket.getActiveSocket]);
   //@ts-ignore
   const socket = getActiveSocket();
   if (socket) {


### PR DESCRIPTION
Fix socket initialization as it causes issue when the user first time uses the app
This pull request includes a change to the `googleSignIn` function in the `authSagas.ts` file to improve the way the `getActiveSocket` method is called.

* [`whatsapp-client/src/redux/sagas/authSagas.ts`](diffhunk://#diff-21d121d32a0112578ad55d3ca77c281a5ebd050e877b9f606d9b4051f1600b8cL46-R46): Modified the `googleSignIn` function to use the `call` effect with the correct context for the `getActiveSocket` method.